### PR TITLE
build: contract upgrade

### DIFF
--- a/.openzeppelin/unknown-2008.json
+++ b/.openzeppelin/unknown-2008.json
@@ -1,0 +1,2508 @@
+{
+  "manifestVersion": "3.2",
+  "proxies": [
+    {
+      "address": "0x8D7b7CE41b63920B931A4e59e1852117ba6eeC22",
+      "txHash": "0x423d1618c5ad2ba45f7988eb928a8ac0db7a9b38c550cfba8e50ea29e8204323",
+      "kind": "uups"
+    }
+  ],
+  "impls": {
+    "79aedbc5f25cd10b0df646b56e080a877f678358fb36d1c979fb904db10fca28": {
+      "address": "0x0fD819e8fFe69B7a03c41CeDacF7b18D5ACDa8Fc",
+      "txHash": "0xdb6738313e29879c748130d934a1751e19657743bf1bcee05a1e11483b116af6",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(RateTier)2939_storage)dyn_storage": {
+            "label": "struct IYieldStreamerTypes.RateTier[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(YieldRate)2933_storage)dyn_storage": {
+            "label": "struct IYieldStreamerTypes.YieldRate[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Group)2925_storage)": {
+            "label": "mapping(address => struct IYieldStreamerTypes.Group)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(YieldState)2951_storage)": {
+            "label": "mapping(address => struct IYieldStreamerTypes.YieldState)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint32,t_array(t_struct(YieldRate)2933_storage)dyn_storage)": {
+            "label": "mapping(uint32 => struct IYieldStreamerTypes.YieldRate[])",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Group)2925_storage": {
+            "label": "struct IYieldStreamerTypes.Group",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_uint32",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)158_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)319_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RateTier)2939_storage": {
+            "label": "struct IYieldStreamerTypes.RateTier",
+            "members": [
+              {
+                "label": "rate",
+                "type": "t_uint48",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "cap",
+                "type": "t_uint64",
+                "offset": 6,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldRate)2933_storage": {
+            "label": "struct IYieldStreamerTypes.YieldRate",
+            "members": [
+              {
+                "label": "tiers",
+                "type": "t_array(t_struct(RateTier)2939_storage)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldState)2951_storage": {
+            "label": "struct IYieldStreamerTypes.YieldState",
+            "members": [
+              {
+                "label": "flags",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "streamYield",
+                "type": "t_uint64",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "accruedYield",
+                "type": "t_uint64",
+                "offset": 9,
+                "slot": "0"
+              },
+              {
+                "label": "lastUpdateTimestamp",
+                "type": "t_uint40",
+                "offset": 17,
+                "slot": "0"
+              },
+              {
+                "label": "lastUpdateBalance",
+                "type": "t_uint64",
+                "offset": 22,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldStreamerHarnessLayout)2422_storage": {
+            "label": "struct YieldStreamerV2Harness.YieldStreamerHarnessLayout",
+            "members": [
+              {
+                "label": "currentBlockTimestamp",
+                "type": "t_uint40",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "usingSpecialBlockTimestamps",
+                "type": "t_bool",
+                "offset": 5,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldStreamerInitializationStorageLayout)2077_storage": {
+            "label": "struct YieldStreamerStorage_Initialization.YieldStreamerInitializationStorageLayout",
+            "members": [
+              {
+                "label": "sourceYieldStreamer",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "groupIds",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldStreamerStorageLayout)2114_storage": {
+            "label": "struct YieldStreamerStorage_Primary.YieldStreamerStorageLayout",
+            "members": [
+              {
+                "label": "underlyingToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "feeReceiver",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "groups",
+                "type": "t_mapping(t_address,t_struct(Group)2925_storage)",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "yieldStates",
+                "type": "t_mapping(t_address,t_struct(YieldState)2951_storage)",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "yieldRates",
+                "type": "t_mapping(t_uint32,t_array(t_struct(YieldRate)2933_storage)dyn_storage)",
+                "offset": 0,
+                "slot": "4"
+              }
+            ],
+            "numberOfBytes": "160"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint40": {
+            "label": "uint40",
+            "numberOfBytes": "5"
+          },
+          "t_uint48": {
+            "label": "uint48",
+            "numberOfBytes": "6"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:cloudwalk.yieldstreamer.harness.storage": [
+            {
+              "contract": "YieldStreamerV2Harness",
+              "label": "currentBlockTimestamp",
+              "type": "t_uint40",
+              "src": "contracts\\v2\\YieldStreamerV2Harness.sol:32",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerV2Harness",
+              "label": "usingSpecialBlockTimestamps",
+              "type": "t_bool",
+              "src": "contracts\\v2\\YieldStreamerV2Harness.sol:33",
+              "offset": 5,
+              "slot": "0"
+            }
+          ],
+          "erc7201:cloudwalk.yieldstreamer.initialization.storage": [
+            {
+              "contract": "YieldStreamerStorage_Initialization",
+              "label": "sourceYieldStreamer",
+              "type": "t_address",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:72",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerStorage_Initialization",
+              "label": "groupIds",
+              "type": "t_mapping(t_bytes32,t_uint256)",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:73",
+              "offset": 0,
+              "slot": "1"
+            }
+          ],
+          "erc7201:cloudwalk.yieldstreamer.primary.storage": [
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "underlyingToken",
+              "type": "t_address",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:120",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "feeReceiver",
+              "type": "t_address",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:121",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "groups",
+              "type": "t_mapping(t_address,t_struct(Group)2925_storage)",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:122",
+              "offset": 0,
+              "slot": "2"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "yieldStates",
+              "type": "t_mapping(t_address,t_struct(YieldState)2951_storage)",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:123",
+              "offset": 0,
+              "slot": "3"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "yieldRates",
+              "type": "t_mapping(t_uint32,t_array(t_struct(YieldRate)2933_storage)dyn_storage)",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:124",
+              "offset": 0,
+              "slot": "4"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\utils\\PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "bdb13b1445ba995153959b37c370d7b8c159b782887ab030fa2b4bad840fcef8": {
+      "address": "0x497B9f7854a16c9748E4972aeb63D7593210Cbd0",
+      "txHash": "0x0b47100405b812c6067defee2074d5de04500ca515c8c4c02044410972457a8f",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(RateTier)3043_storage)dyn_storage": {
+            "label": "struct IYieldStreamerTypes.RateTier[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(YieldRate)3037_storage)dyn_storage": {
+            "label": "struct IYieldStreamerTypes.YieldRate[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Group)3029_storage)": {
+            "label": "mapping(address => struct IYieldStreamerTypes.Group)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(YieldState)3055_storage)": {
+            "label": "mapping(address => struct IYieldStreamerTypes.YieldState)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint32,t_array(t_struct(YieldRate)3037_storage)dyn_storage)": {
+            "label": "mapping(uint32 => struct IYieldStreamerTypes.YieldRate[])",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Group)3029_storage": {
+            "label": "struct IYieldStreamerTypes.Group",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_uint32",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)158_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)319_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RateTier)3043_storage": {
+            "label": "struct IYieldStreamerTypes.RateTier",
+            "members": [
+              {
+                "label": "rate",
+                "type": "t_uint48",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "cap",
+                "type": "t_uint64",
+                "offset": 6,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldRate)3037_storage": {
+            "label": "struct IYieldStreamerTypes.YieldRate",
+            "members": [
+              {
+                "label": "tiers",
+                "type": "t_array(t_struct(RateTier)3043_storage)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldState)3055_storage": {
+            "label": "struct IYieldStreamerTypes.YieldState",
+            "members": [
+              {
+                "label": "flags",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "streamYield",
+                "type": "t_uint64",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "accruedYield",
+                "type": "t_uint64",
+                "offset": 9,
+                "slot": "0"
+              },
+              {
+                "label": "lastUpdateTimestamp",
+                "type": "t_uint40",
+                "offset": 17,
+                "slot": "0"
+              },
+              {
+                "label": "lastUpdateBalance",
+                "type": "t_uint64",
+                "offset": 22,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldStreamerHarnessLayout)2454_storage": {
+            "label": "struct YieldStreamerV2Harness.YieldStreamerHarnessLayout",
+            "members": [
+              {
+                "label": "currentBlockTimestamp",
+                "type": "t_uint40",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "usingSpecialBlockTimestamps",
+                "type": "t_bool",
+                "offset": 5,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldStreamerInitializationStorageLayout)2109_storage": {
+            "label": "struct YieldStreamerStorage_Initialization.YieldStreamerInitializationStorageLayout",
+            "members": [
+              {
+                "label": "sourceYieldStreamer",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "groupIds",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldStreamerStorageLayout)2146_storage": {
+            "label": "struct YieldStreamerStorage_Primary.YieldStreamerStorageLayout",
+            "members": [
+              {
+                "label": "underlyingToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "feeReceiver",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "groups",
+                "type": "t_mapping(t_address,t_struct(Group)3029_storage)",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "yieldStates",
+                "type": "t_mapping(t_address,t_struct(YieldState)3055_storage)",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "yieldRates",
+                "type": "t_mapping(t_uint32,t_array(t_struct(YieldRate)3037_storage)dyn_storage)",
+                "offset": 0,
+                "slot": "4"
+              }
+            ],
+            "numberOfBytes": "160"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint40": {
+            "label": "uint40",
+            "numberOfBytes": "5"
+          },
+          "t_uint48": {
+            "label": "uint48",
+            "numberOfBytes": "6"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:cloudwalk.yieldstreamer.harness.storage": [
+            {
+              "contract": "YieldStreamerV2Harness",
+              "label": "currentBlockTimestamp",
+              "type": "t_uint40",
+              "src": "contracts\\v2\\YieldStreamerV2Harness.sol:32",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerV2Harness",
+              "label": "usingSpecialBlockTimestamps",
+              "type": "t_bool",
+              "src": "contracts\\v2\\YieldStreamerV2Harness.sol:33",
+              "offset": 5,
+              "slot": "0"
+            }
+          ],
+          "erc7201:cloudwalk.yieldstreamer.initialization.storage": [
+            {
+              "contract": "YieldStreamerStorage_Initialization",
+              "label": "sourceYieldStreamer",
+              "type": "t_address",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:72",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerStorage_Initialization",
+              "label": "groupIds",
+              "type": "t_mapping(t_bytes32,t_uint256)",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:73",
+              "offset": 0,
+              "slot": "1"
+            }
+          ],
+          "erc7201:cloudwalk.yieldstreamer.primary.storage": [
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "underlyingToken",
+              "type": "t_address",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:120",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "feeReceiver",
+              "type": "t_address",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:121",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "groups",
+              "type": "t_mapping(t_address,t_struct(Group)3029_storage)",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:122",
+              "offset": 0,
+              "slot": "2"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "yieldStates",
+              "type": "t_mapping(t_address,t_struct(YieldState)3055_storage)",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:123",
+              "offset": 0,
+              "slot": "3"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "yieldRates",
+              "type": "t_mapping(t_uint32,t_array(t_struct(YieldRate)3037_storage)dyn_storage)",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:124",
+              "offset": 0,
+              "slot": "4"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\utils\\PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "175b4e18604ade341ba48cf6745e41dcae1fb89331ae9bd8313bf090a38d26f4": {
+      "address": "0x8eA0d4F09e2feE6648004E8e3ED5CD0C35C2a028",
+      "txHash": "0xd417f39ab629ee284a3afbf43c4f047ea9ab64cc4172e097f78137e37df010bd",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(RateTier)3306_storage)dyn_storage": {
+            "label": "struct IYieldStreamerTypes.RateTier[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(YieldRate)3300_storage)dyn_storage": {
+            "label": "struct IYieldStreamerTypes.YieldRate[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Group)3292_storage)": {
+            "label": "mapping(address => struct IYieldStreamerTypes.Group)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(YieldState)3318_storage)": {
+            "label": "mapping(address => struct IYieldStreamerTypes.YieldState)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint32,t_array(t_struct(YieldRate)3300_storage)dyn_storage)": {
+            "label": "mapping(uint32 => struct IYieldStreamerTypes.YieldRate[])",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Group)3292_storage": {
+            "label": "struct IYieldStreamerTypes.Group",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_uint32",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)158_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)319_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RateTier)3306_storage": {
+            "label": "struct IYieldStreamerTypes.RateTier",
+            "members": [
+              {
+                "label": "rate",
+                "type": "t_uint48",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "cap",
+                "type": "t_uint64",
+                "offset": 6,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldRate)3300_storage": {
+            "label": "struct IYieldStreamerTypes.YieldRate",
+            "members": [
+              {
+                "label": "tiers",
+                "type": "t_array(t_struct(RateTier)3306_storage)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldState)3318_storage": {
+            "label": "struct IYieldStreamerTypes.YieldState",
+            "members": [
+              {
+                "label": "flags",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "streamYield",
+                "type": "t_uint64",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "accruedYield",
+                "type": "t_uint64",
+                "offset": 9,
+                "slot": "0"
+              },
+              {
+                "label": "lastUpdateTimestamp",
+                "type": "t_uint40",
+                "offset": 17,
+                "slot": "0"
+              },
+              {
+                "label": "lastUpdateBalance",
+                "type": "t_uint64",
+                "offset": 22,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldStreamerHarnessLayout)2717_storage": {
+            "label": "struct YieldStreamerV2Harness.YieldStreamerHarnessLayout",
+            "members": [
+              {
+                "label": "currentBlockTimestamp",
+                "type": "t_uint40",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "usingSpecialBlockTimestamps",
+                "type": "t_bool",
+                "offset": 5,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldStreamerInitializationStorageLayout)2372_storage": {
+            "label": "struct YieldStreamerStorage_Initialization.YieldStreamerInitializationStorageLayout",
+            "members": [
+              {
+                "label": "sourceYieldStreamer",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "groupIds",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldStreamerStorageLayout)2409_storage": {
+            "label": "struct YieldStreamerStorage_Primary.YieldStreamerStorageLayout",
+            "members": [
+              {
+                "label": "underlyingToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "feeReceiver",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "groups",
+                "type": "t_mapping(t_address,t_struct(Group)3292_storage)",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "yieldStates",
+                "type": "t_mapping(t_address,t_struct(YieldState)3318_storage)",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "yieldRates",
+                "type": "t_mapping(t_uint32,t_array(t_struct(YieldRate)3300_storage)dyn_storage)",
+                "offset": 0,
+                "slot": "4"
+              }
+            ],
+            "numberOfBytes": "160"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint40": {
+            "label": "uint40",
+            "numberOfBytes": "5"
+          },
+          "t_uint48": {
+            "label": "uint48",
+            "numberOfBytes": "6"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:cloudwalk.yieldstreamer.harness.storage": [
+            {
+              "contract": "YieldStreamerV2Harness",
+              "label": "currentBlockTimestamp",
+              "type": "t_uint40",
+              "src": "contracts\\v2\\YieldStreamerV2Harness.sol:32",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerV2Harness",
+              "label": "usingSpecialBlockTimestamps",
+              "type": "t_bool",
+              "src": "contracts\\v2\\YieldStreamerV2Harness.sol:33",
+              "offset": 5,
+              "slot": "0"
+            }
+          ],
+          "erc7201:cloudwalk.yieldstreamer.initialization.storage": [
+            {
+              "contract": "YieldStreamerStorage_Initialization",
+              "label": "sourceYieldStreamer",
+              "type": "t_address",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:72",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerStorage_Initialization",
+              "label": "groupIds",
+              "type": "t_mapping(t_bytes32,t_uint256)",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:73",
+              "offset": 0,
+              "slot": "1"
+            }
+          ],
+          "erc7201:cloudwalk.yieldstreamer.primary.storage": [
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "underlyingToken",
+              "type": "t_address",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:120",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "feeReceiver",
+              "type": "t_address",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:121",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "groups",
+              "type": "t_mapping(t_address,t_struct(Group)3292_storage)",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:122",
+              "offset": 0,
+              "slot": "2"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "yieldStates",
+              "type": "t_mapping(t_address,t_struct(YieldState)3318_storage)",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:123",
+              "offset": 0,
+              "slot": "3"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "yieldRates",
+              "type": "t_mapping(t_uint32,t_array(t_struct(YieldRate)3300_storage)dyn_storage)",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:124",
+              "offset": 0,
+              "slot": "4"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\utils\\PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "bba96bbf44fdee0a6ef724689c0030fba877a24f5864abab9a92d71d4a8cb700": {
+      "address": "0x0c602D8124D3BE725B810cdDC29FdA33838DCd79",
+      "txHash": "0x2c8b20b18f51a5ddfa2d50993f05699d97db98af19b5e22e0b1c2bb38df6f2f8",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(RateTier)3043_storage)dyn_storage": {
+            "label": "struct IYieldStreamerTypes.RateTier[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(YieldRate)3037_storage)dyn_storage": {
+            "label": "struct IYieldStreamerTypes.YieldRate[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Group)3029_storage)": {
+            "label": "mapping(address => struct IYieldStreamerTypes.Group)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(YieldState)3055_storage)": {
+            "label": "mapping(address => struct IYieldStreamerTypes.YieldState)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint32,t_array(t_struct(YieldRate)3037_storage)dyn_storage)": {
+            "label": "mapping(uint32 => struct IYieldStreamerTypes.YieldRate[])",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Group)3029_storage": {
+            "label": "struct IYieldStreamerTypes.Group",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_uint32",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)158_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)319_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RateTier)3043_storage": {
+            "label": "struct IYieldStreamerTypes.RateTier",
+            "members": [
+              {
+                "label": "rate",
+                "type": "t_uint48",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "cap",
+                "type": "t_uint64",
+                "offset": 6,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldRate)3037_storage": {
+            "label": "struct IYieldStreamerTypes.YieldRate",
+            "members": [
+              {
+                "label": "tiers",
+                "type": "t_array(t_struct(RateTier)3043_storage)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldState)3055_storage": {
+            "label": "struct IYieldStreamerTypes.YieldState",
+            "members": [
+              {
+                "label": "flags",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "streamYield",
+                "type": "t_uint64",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "accruedYield",
+                "type": "t_uint64",
+                "offset": 9,
+                "slot": "0"
+              },
+              {
+                "label": "lastUpdateTimestamp",
+                "type": "t_uint40",
+                "offset": 17,
+                "slot": "0"
+              },
+              {
+                "label": "lastUpdateBalance",
+                "type": "t_uint64",
+                "offset": 22,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldStreamerHarnessLayout)2454_storage": {
+            "label": "struct YieldStreamerV2Harness.YieldStreamerHarnessLayout",
+            "members": [
+              {
+                "label": "currentBlockTimestamp",
+                "type": "t_uint40",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "usingSpecialBlockTimestamps",
+                "type": "t_bool",
+                "offset": 5,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldStreamerInitializationStorageLayout)2109_storage": {
+            "label": "struct YieldStreamerStorage_Initialization.YieldStreamerInitializationStorageLayout",
+            "members": [
+              {
+                "label": "sourceYieldStreamer",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "groupIds",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldStreamerStorageLayout)2146_storage": {
+            "label": "struct YieldStreamerStorage_Primary.YieldStreamerStorageLayout",
+            "members": [
+              {
+                "label": "underlyingToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "feeReceiver",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "groups",
+                "type": "t_mapping(t_address,t_struct(Group)3029_storage)",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "yieldStates",
+                "type": "t_mapping(t_address,t_struct(YieldState)3055_storage)",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "yieldRates",
+                "type": "t_mapping(t_uint32,t_array(t_struct(YieldRate)3037_storage)dyn_storage)",
+                "offset": 0,
+                "slot": "4"
+              }
+            ],
+            "numberOfBytes": "160"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint40": {
+            "label": "uint40",
+            "numberOfBytes": "5"
+          },
+          "t_uint48": {
+            "label": "uint48",
+            "numberOfBytes": "6"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:cloudwalk.yieldstreamer.harness.storage": [
+            {
+              "contract": "YieldStreamerV2Harness",
+              "label": "currentBlockTimestamp",
+              "type": "t_uint40",
+              "src": "contracts\\v2\\YieldStreamerV2Harness.sol:32",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerV2Harness",
+              "label": "usingSpecialBlockTimestamps",
+              "type": "t_bool",
+              "src": "contracts\\v2\\YieldStreamerV2Harness.sol:33",
+              "offset": 5,
+              "slot": "0"
+            }
+          ],
+          "erc7201:cloudwalk.yieldstreamer.initialization.storage": [
+            {
+              "contract": "YieldStreamerStorage_Initialization",
+              "label": "sourceYieldStreamer",
+              "type": "t_address",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:72",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerStorage_Initialization",
+              "label": "groupIds",
+              "type": "t_mapping(t_bytes32,t_uint256)",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:73",
+              "offset": 0,
+              "slot": "1"
+            }
+          ],
+          "erc7201:cloudwalk.yieldstreamer.primary.storage": [
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "underlyingToken",
+              "type": "t_address",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:120",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "feeReceiver",
+              "type": "t_address",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:121",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "groups",
+              "type": "t_mapping(t_address,t_struct(Group)3029_storage)",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:122",
+              "offset": 0,
+              "slot": "2"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "yieldStates",
+              "type": "t_mapping(t_address,t_struct(YieldState)3055_storage)",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:123",
+              "offset": 0,
+              "slot": "3"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "yieldRates",
+              "type": "t_mapping(t_uint32,t_array(t_struct(YieldRate)3037_storage)dyn_storage)",
+              "src": "contracts\\v2\\YieldStreamerStorage.sol:124",
+              "offset": 0,
+              "slot": "4"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\utils\\PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "681688f8477c0318f130e23288e9d377fd446b248dfdd17ffef05d2e113a9d47": {
+      "address": "0x8223DDF5e1e96f76920D5CF5AA4F37d4F1457fe0",
+      "txHash": "0xb205676f8306f5b8cc1faa98ad95b495a2be98e749686bb1eb99d8b7d31189c2",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(RateTier)3093_storage)dyn_storage": {
+            "label": "struct IYieldStreamerTypes.RateTier[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(YieldRate)3087_storage)dyn_storage": {
+            "label": "struct IYieldStreamerTypes.YieldRate[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Group)3079_storage)": {
+            "label": "mapping(address => struct IYieldStreamerTypes.Group)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(YieldState)3105_storage)": {
+            "label": "mapping(address => struct IYieldStreamerTypes.YieldState)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint32,t_array(t_struct(YieldRate)3087_storage)dyn_storage)": {
+            "label": "mapping(uint32 => struct IYieldStreamerTypes.YieldRate[])",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Group)3079_storage": {
+            "label": "struct IYieldStreamerTypes.Group",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_uint32",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)145_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)291_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RateTier)3093_storage": {
+            "label": "struct IYieldStreamerTypes.RateTier",
+            "members": [
+              {
+                "label": "rate",
+                "type": "t_uint48",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "cap",
+                "type": "t_uint64",
+                "offset": 6,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldRate)3087_storage": {
+            "label": "struct IYieldStreamerTypes.YieldRate",
+            "members": [
+              {
+                "label": "tiers",
+                "type": "t_array(t_struct(RateTier)3093_storage)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldState)3105_storage": {
+            "label": "struct IYieldStreamerTypes.YieldState",
+            "members": [
+              {
+                "label": "flags",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "streamYield",
+                "type": "t_uint64",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "accruedYield",
+                "type": "t_uint64",
+                "offset": 9,
+                "slot": "0"
+              },
+              {
+                "label": "lastUpdateTimestamp",
+                "type": "t_uint40",
+                "offset": 17,
+                "slot": "0"
+              },
+              {
+                "label": "lastUpdateBalance",
+                "type": "t_uint64",
+                "offset": 22,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldStreamerHarnessLayout)3417_storage": {
+            "label": "struct YieldStreamerHarness.YieldStreamerHarnessLayout",
+            "members": [
+              {
+                "label": "currentBlockTimestamp",
+                "type": "t_uint40",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "usingSpecialBlockTimestamps",
+                "type": "t_bool",
+                "offset": 5,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldStreamerInitializationStorageLayout)2605_storage": {
+            "label": "struct YieldStreamerStorage_Initialization.YieldStreamerInitializationStorageLayout",
+            "members": [
+              {
+                "label": "sourceYieldStreamer",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "groupIds",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldStreamerStorageLayout)2642_storage": {
+            "label": "struct YieldStreamerStorage_Primary.YieldStreamerStorageLayout",
+            "members": [
+              {
+                "label": "underlyingToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "feeReceiver",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "groups",
+                "type": "t_mapping(t_address,t_struct(Group)3079_storage)",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "yieldStates",
+                "type": "t_mapping(t_address,t_struct(YieldState)3105_storage)",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "yieldRates",
+                "type": "t_mapping(t_uint32,t_array(t_struct(YieldRate)3087_storage)dyn_storage)",
+                "offset": 0,
+                "slot": "4"
+              }
+            ],
+            "numberOfBytes": "160"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint40": {
+            "label": "uint40",
+            "numberOfBytes": "5"
+          },
+          "t_uint48": {
+            "label": "uint48",
+            "numberOfBytes": "6"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:cloudwalk.yieldstreamer.harness.storage": [
+            {
+              "contract": "YieldStreamerHarness",
+              "label": "currentBlockTimestamp",
+              "type": "t_uint40",
+              "src": "contracts\\testable\\YieldStreamerHarness.sol:32",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerHarness",
+              "label": "usingSpecialBlockTimestamps",
+              "type": "t_bool",
+              "src": "contracts\\testable\\YieldStreamerHarness.sol:33",
+              "offset": 5,
+              "slot": "0"
+            }
+          ],
+          "erc7201:cloudwalk.yieldstreamer.initialization.storage": [
+            {
+              "contract": "YieldStreamerStorage_Initialization",
+              "label": "sourceYieldStreamer",
+              "type": "t_address",
+              "src": "contracts\\YieldStreamerStorage.sol:72",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerStorage_Initialization",
+              "label": "groupIds",
+              "type": "t_mapping(t_bytes32,t_uint256)",
+              "src": "contracts\\YieldStreamerStorage.sol:73",
+              "offset": 0,
+              "slot": "1"
+            }
+          ],
+          "erc7201:cloudwalk.yieldstreamer.primary.storage": [
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "underlyingToken",
+              "type": "t_address",
+              "src": "contracts\\YieldStreamerStorage.sol:120",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "feeReceiver",
+              "type": "t_address",
+              "src": "contracts\\YieldStreamerStorage.sol:121",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "groups",
+              "type": "t_mapping(t_address,t_struct(Group)3079_storage)",
+              "src": "contracts\\YieldStreamerStorage.sol:122",
+              "offset": 0,
+              "slot": "2"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "yieldStates",
+              "type": "t_mapping(t_address,t_struct(YieldState)3105_storage)",
+              "src": "contracts\\YieldStreamerStorage.sol:123",
+              "offset": 0,
+              "slot": "3"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "yieldRates",
+              "type": "t_mapping(t_uint32,t_array(t_struct(YieldRate)3087_storage)dyn_storage)",
+              "src": "contracts\\YieldStreamerStorage.sol:124",
+              "offset": 0,
+              "slot": "4"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\utils\\PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "024dd868f3852021338c6a296d57fc4769a32c6d755311521c3fb800e532c238": {
+      "address": "0x620eF3E6E0F148475B63ef2b96358F9CBAbbAa03",
+      "txHash": "0x85699162ece8bcb21cac6892240bb61519dd05307912bb34dee07a2390e23e2c",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(RateTier)3093_storage)dyn_storage": {
+            "label": "struct IYieldStreamerTypes.RateTier[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(YieldRate)3087_storage)dyn_storage": {
+            "label": "struct IYieldStreamerTypes.YieldRate[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Group)3079_storage)": {
+            "label": "mapping(address => struct IYieldStreamerTypes.Group)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(YieldState)3105_storage)": {
+            "label": "mapping(address => struct IYieldStreamerTypes.YieldState)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint32,t_array(t_struct(YieldRate)3087_storage)dyn_storage)": {
+            "label": "mapping(uint32 => struct IYieldStreamerTypes.YieldRate[])",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Group)3079_storage": {
+            "label": "struct IYieldStreamerTypes.Group",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_uint32",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)145_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)291_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RateTier)3093_storage": {
+            "label": "struct IYieldStreamerTypes.RateTier",
+            "members": [
+              {
+                "label": "rate",
+                "type": "t_uint48",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "cap",
+                "type": "t_uint64",
+                "offset": 6,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldRate)3087_storage": {
+            "label": "struct IYieldStreamerTypes.YieldRate",
+            "members": [
+              {
+                "label": "tiers",
+                "type": "t_array(t_struct(RateTier)3093_storage)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldState)3105_storage": {
+            "label": "struct IYieldStreamerTypes.YieldState",
+            "members": [
+              {
+                "label": "flags",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "streamYield",
+                "type": "t_uint64",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "accruedYield",
+                "type": "t_uint64",
+                "offset": 9,
+                "slot": "0"
+              },
+              {
+                "label": "lastUpdateTimestamp",
+                "type": "t_uint40",
+                "offset": 17,
+                "slot": "0"
+              },
+              {
+                "label": "lastUpdateBalance",
+                "type": "t_uint64",
+                "offset": 22,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldStreamerHarnessLayout)3417_storage": {
+            "label": "struct YieldStreamerHarness.YieldStreamerHarnessLayout",
+            "members": [
+              {
+                "label": "currentBlockTimestamp",
+                "type": "t_uint40",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "usingSpecialBlockTimestamps",
+                "type": "t_bool",
+                "offset": 5,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldStreamerInitializationStorageLayout)2605_storage": {
+            "label": "struct YieldStreamerStorage_Initialization.YieldStreamerInitializationStorageLayout",
+            "members": [
+              {
+                "label": "sourceYieldStreamer",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "groupIds",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldStreamerStorageLayout)2642_storage": {
+            "label": "struct YieldStreamerStorage_Primary.YieldStreamerStorageLayout",
+            "members": [
+              {
+                "label": "underlyingToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "feeReceiver",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "groups",
+                "type": "t_mapping(t_address,t_struct(Group)3079_storage)",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "yieldStates",
+                "type": "t_mapping(t_address,t_struct(YieldState)3105_storage)",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "yieldRates",
+                "type": "t_mapping(t_uint32,t_array(t_struct(YieldRate)3087_storage)dyn_storage)",
+                "offset": 0,
+                "slot": "4"
+              }
+            ],
+            "numberOfBytes": "160"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint40": {
+            "label": "uint40",
+            "numberOfBytes": "5"
+          },
+          "t_uint48": {
+            "label": "uint48",
+            "numberOfBytes": "6"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:cloudwalk.yieldstreamer.harness.storage": [
+            {
+              "contract": "YieldStreamerHarness",
+              "label": "currentBlockTimestamp",
+              "type": "t_uint40",
+              "src": "contracts\\testable\\YieldStreamerHarness.sol:32",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerHarness",
+              "label": "usingSpecialBlockTimestamps",
+              "type": "t_bool",
+              "src": "contracts\\testable\\YieldStreamerHarness.sol:33",
+              "offset": 5,
+              "slot": "0"
+            }
+          ],
+          "erc7201:cloudwalk.yieldstreamer.initialization.storage": [
+            {
+              "contract": "YieldStreamerStorage_Initialization",
+              "label": "sourceYieldStreamer",
+              "type": "t_address",
+              "src": "contracts\\YieldStreamerStorage.sol:72",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerStorage_Initialization",
+              "label": "groupIds",
+              "type": "t_mapping(t_bytes32,t_uint256)",
+              "src": "contracts\\YieldStreamerStorage.sol:73",
+              "offset": 0,
+              "slot": "1"
+            }
+          ],
+          "erc7201:cloudwalk.yieldstreamer.primary.storage": [
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "underlyingToken",
+              "type": "t_address",
+              "src": "contracts\\YieldStreamerStorage.sol:120",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "feeReceiver",
+              "type": "t_address",
+              "src": "contracts\\YieldStreamerStorage.sol:121",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "groups",
+              "type": "t_mapping(t_address,t_struct(Group)3079_storage)",
+              "src": "contracts\\YieldStreamerStorage.sol:122",
+              "offset": 0,
+              "slot": "2"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "yieldStates",
+              "type": "t_mapping(t_address,t_struct(YieldState)3105_storage)",
+              "src": "contracts\\YieldStreamerStorage.sol:123",
+              "offset": 0,
+              "slot": "3"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "yieldRates",
+              "type": "t_mapping(t_uint32,t_array(t_struct(YieldRate)3087_storage)dyn_storage)",
+              "src": "contracts\\YieldStreamerStorage.sol:124",
+              "offset": 0,
+              "slot": "4"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\utils\\PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/.openzeppelin/unknown-2009.json
+++ b/.openzeppelin/unknown-2009.json
@@ -1,0 +1,392 @@
+{
+  "manifestVersion": "3.2",
+  "proxies": [
+    {
+      "address": "0xf1Db417ec9F5f10F45dD1205d5e0Bf7f3E66b71e",
+      "txHash": "0x4c031ecf7f1f504362dea2b797826cfb1352dc2f65bc8cfe51ed5c56416db5ba",
+      "kind": "uups"
+    }
+  ],
+  "impls": {
+    "340a5437cc8a06d5d279a69ba9e8eb03cd6783e40316672e9e8990fe86e57cf9": {
+      "address": "0x3CB4D4c283d6c2f5B70E3c608356d86E2149333b",
+      "txHash": "0x273b304e8b1859a93399b1657eabcb023bc8dfb215efda583bb959f86adce441",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(RateTier)3093_storage)dyn_storage": {
+            "label": "struct IYieldStreamerTypes.RateTier[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(YieldRate)3087_storage)dyn_storage": {
+            "label": "struct IYieldStreamerTypes.YieldRate[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Group)3079_storage)": {
+            "label": "mapping(address => struct IYieldStreamerTypes.Group)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(YieldState)3105_storage)": {
+            "label": "mapping(address => struct IYieldStreamerTypes.YieldState)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint32,t_array(t_struct(YieldRate)3087_storage)dyn_storage)": {
+            "label": "mapping(uint32 => struct IYieldStreamerTypes.YieldRate[])",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Group)3079_storage": {
+            "label": "struct IYieldStreamerTypes.Group",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_uint32",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)145_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)291_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RateTier)3093_storage": {
+            "label": "struct IYieldStreamerTypes.RateTier",
+            "members": [
+              {
+                "label": "rate",
+                "type": "t_uint48",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "cap",
+                "type": "t_uint64",
+                "offset": 6,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldRate)3087_storage": {
+            "label": "struct IYieldStreamerTypes.YieldRate",
+            "members": [
+              {
+                "label": "tiers",
+                "type": "t_array(t_struct(RateTier)3093_storage)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldState)3105_storage": {
+            "label": "struct IYieldStreamerTypes.YieldState",
+            "members": [
+              {
+                "label": "flags",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "streamYield",
+                "type": "t_uint64",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "accruedYield",
+                "type": "t_uint64",
+                "offset": 9,
+                "slot": "0"
+              },
+              {
+                "label": "lastUpdateTimestamp",
+                "type": "t_uint40",
+                "offset": 17,
+                "slot": "0"
+              },
+              {
+                "label": "lastUpdateBalance",
+                "type": "t_uint64",
+                "offset": 22,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldStreamerInitializationStorageLayout)2605_storage": {
+            "label": "struct YieldStreamerStorage_Initialization.YieldStreamerInitializationStorageLayout",
+            "members": [
+              {
+                "label": "sourceYieldStreamer",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "groupIds",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldStreamerStorageLayout)2642_storage": {
+            "label": "struct YieldStreamerStorage_Primary.YieldStreamerStorageLayout",
+            "members": [
+              {
+                "label": "underlyingToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "feeReceiver",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "groups",
+                "type": "t_mapping(t_address,t_struct(Group)3079_storage)",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "yieldStates",
+                "type": "t_mapping(t_address,t_struct(YieldState)3105_storage)",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "yieldRates",
+                "type": "t_mapping(t_uint32,t_array(t_struct(YieldRate)3087_storage)dyn_storage)",
+                "offset": 0,
+                "slot": "4"
+              }
+            ],
+            "numberOfBytes": "160"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint40": {
+            "label": "uint40",
+            "numberOfBytes": "5"
+          },
+          "t_uint48": {
+            "label": "uint48",
+            "numberOfBytes": "6"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:cloudwalk.yieldstreamer.initialization.storage": [
+            {
+              "contract": "YieldStreamerStorage_Initialization",
+              "label": "sourceYieldStreamer",
+              "type": "t_address",
+              "src": "contracts\\YieldStreamerStorage.sol:72",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerStorage_Initialization",
+              "label": "groupIds",
+              "type": "t_mapping(t_bytes32,t_uint256)",
+              "src": "contracts\\YieldStreamerStorage.sol:73",
+              "offset": 0,
+              "slot": "1"
+            }
+          ],
+          "erc7201:cloudwalk.yieldstreamer.primary.storage": [
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "underlyingToken",
+              "type": "t_address",
+              "src": "contracts\\YieldStreamerStorage.sol:120",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "feeReceiver",
+              "type": "t_address",
+              "src": "contracts\\YieldStreamerStorage.sol:121",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "groups",
+              "type": "t_mapping(t_address,t_struct(Group)3079_storage)",
+              "src": "contracts\\YieldStreamerStorage.sol:122",
+              "offset": 0,
+              "slot": "2"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "yieldStates",
+              "type": "t_mapping(t_address,t_struct(YieldState)3105_storage)",
+              "src": "contracts\\YieldStreamerStorage.sol:123",
+              "offset": 0,
+              "slot": "3"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "yieldRates",
+              "type": "t_mapping(t_uint32,t_array(t_struct(YieldRate)3087_storage)dyn_storage)",
+              "src": "contracts\\YieldStreamerStorage.sol:124",
+              "offset": 0,
+              "slot": "4"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\utils\\PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Main changes

1. The `YieldStreamerHarness` contract has been updated in Testnet.
2. The `YieldStreamer` contract has been deployed in Mainnet.
3. The `.openzeppelin` network files have been updated accordingly