### PR TITLE
build: contract upgrade

### DIFF
--- a/.openzeppelin/unknown-2008.json
+++ b/.openzeppelin/unknown-2008.json
@@ -2503,6 +2503,838 @@
           ]
         }
       }
+    },
+    "6e7c80db1b8dac0112154ae1d510e0a518f446edf7af7f06d31bee392024d5e4": {
+      "address": "0x20273d69DBb40216D38533cDa0268FFd7ed4FC18",
+      "txHash": "0x957becba20ec17f43f2fc2d9a4769a6b41df96597c13ba96a32240e8b48ca94f",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(RateTier)2857_storage)dyn_storage": {
+            "label": "struct IYieldStreamerTypes.RateTier[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(YieldRate)2851_storage)dyn_storage": {
+            "label": "struct IYieldStreamerTypes.YieldRate[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Group)2843_storage)": {
+            "label": "mapping(address => struct IYieldStreamerTypes.Group)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(YieldState)2869_storage)": {
+            "label": "mapping(address => struct IYieldStreamerTypes.YieldState)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint32,t_array(t_struct(YieldRate)2851_storage)dyn_storage)": {
+            "label": "mapping(uint32 => struct IYieldStreamerTypes.YieldRate[])",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Group)2843_storage": {
+            "label": "struct IYieldStreamerTypes.Group",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_uint32",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)145_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)291_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RateTier)2857_storage": {
+            "label": "struct IYieldStreamerTypes.RateTier",
+            "members": [
+              {
+                "label": "rate",
+                "type": "t_uint48",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "cap",
+                "type": "t_uint64",
+                "offset": 6,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldRate)2851_storage": {
+            "label": "struct IYieldStreamerTypes.YieldRate",
+            "members": [
+              {
+                "label": "tiers",
+                "type": "t_array(t_struct(RateTier)2857_storage)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldState)2869_storage": {
+            "label": "struct IYieldStreamerTypes.YieldState",
+            "members": [
+              {
+                "label": "flags",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "streamYield",
+                "type": "t_uint64",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "accruedYield",
+                "type": "t_uint64",
+                "offset": 9,
+                "slot": "0"
+              },
+              {
+                "label": "lastUpdateTimestamp",
+                "type": "t_uint40",
+                "offset": 17,
+                "slot": "0"
+              },
+              {
+                "label": "lastUpdateBalance",
+                "type": "t_uint64",
+                "offset": 22,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldStreamerHarnessLayout)3030_storage": {
+            "label": "struct YieldStreamerHarness.YieldStreamerHarnessLayout",
+            "members": [
+              {
+                "label": "currentBlockTimestamp",
+                "type": "t_uint40",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "usingSpecialBlockTimestamps",
+                "type": "t_bool",
+                "offset": 5,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldStreamerInitializationStorageLayout)2367_storage": {
+            "label": "struct YieldStreamerStorage_Initialization.YieldStreamerInitializationStorageLayout",
+            "members": [
+              {
+                "label": "sourceYieldStreamer",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "groupIds",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldStreamerStorageLayout)2404_storage": {
+            "label": "struct YieldStreamerStorage_Primary.YieldStreamerStorageLayout",
+            "members": [
+              {
+                "label": "underlyingToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "feeReceiver",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "groups",
+                "type": "t_mapping(t_address,t_struct(Group)2843_storage)",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "yieldStates",
+                "type": "t_mapping(t_address,t_struct(YieldState)2869_storage)",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "yieldRates",
+                "type": "t_mapping(t_uint32,t_array(t_struct(YieldRate)2851_storage)dyn_storage)",
+                "offset": 0,
+                "slot": "4"
+              }
+            ],
+            "numberOfBytes": "160"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint40": {
+            "label": "uint40",
+            "numberOfBytes": "5"
+          },
+          "t_uint48": {
+            "label": "uint48",
+            "numberOfBytes": "6"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:cloudwalk.yieldstreamer.harness.storage": [
+            {
+              "contract": "YieldStreamerHarness",
+              "label": "currentBlockTimestamp",
+              "type": "t_uint40",
+              "src": "contracts\\testable\\YieldStreamerHarness.sol:32",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerHarness",
+              "label": "usingSpecialBlockTimestamps",
+              "type": "t_bool",
+              "src": "contracts\\testable\\YieldStreamerHarness.sol:33",
+              "offset": 5,
+              "slot": "0"
+            }
+          ],
+          "erc7201:cloudwalk.yieldstreamer.initialization.storage": [
+            {
+              "contract": "YieldStreamerStorage_Initialization",
+              "label": "sourceYieldStreamer",
+              "type": "t_address",
+              "src": "contracts\\YieldStreamerStorage.sol:72",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerStorage_Initialization",
+              "label": "groupIds",
+              "type": "t_mapping(t_bytes32,t_uint256)",
+              "src": "contracts\\YieldStreamerStorage.sol:73",
+              "offset": 0,
+              "slot": "1"
+            }
+          ],
+          "erc7201:cloudwalk.yieldstreamer.primary.storage": [
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "underlyingToken",
+              "type": "t_address",
+              "src": "contracts\\YieldStreamerStorage.sol:120",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "feeReceiver",
+              "type": "t_address",
+              "src": "contracts\\YieldStreamerStorage.sol:121",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "groups",
+              "type": "t_mapping(t_address,t_struct(Group)2843_storage)",
+              "src": "contracts\\YieldStreamerStorage.sol:122",
+              "offset": 0,
+              "slot": "2"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "yieldStates",
+              "type": "t_mapping(t_address,t_struct(YieldState)2869_storage)",
+              "src": "contracts\\YieldStreamerStorage.sol:123",
+              "offset": 0,
+              "slot": "3"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "yieldRates",
+              "type": "t_mapping(t_uint32,t_array(t_struct(YieldRate)2851_storage)dyn_storage)",
+              "src": "contracts\\YieldStreamerStorage.sol:124",
+              "offset": 0,
+              "slot": "4"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\utils\\PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "21aa962969e75630a416f074bb50e93305ed06fca6223cf150d55f675662fd65": {
+      "address": "0x5Ef3cC48D04E5202596ba1b413925600c0d84E1A",
+      "txHash": "0xb4e662916034c2d7f0ed677ff8570dfd4952fec6966f4f2a987062901b2fac69",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(RateTier)2857_storage)dyn_storage": {
+            "label": "struct IYieldStreamerTypes.RateTier[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(YieldRate)2851_storage)dyn_storage": {
+            "label": "struct IYieldStreamerTypes.YieldRate[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Group)2843_storage)": {
+            "label": "mapping(address => struct IYieldStreamerTypes.Group)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(YieldState)2869_storage)": {
+            "label": "mapping(address => struct IYieldStreamerTypes.YieldState)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint32,t_array(t_struct(YieldRate)2851_storage)dyn_storage)": {
+            "label": "mapping(uint32 => struct IYieldStreamerTypes.YieldRate[])",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Group)2843_storage": {
+            "label": "struct IYieldStreamerTypes.Group",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_uint32",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)145_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)291_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RateTier)2857_storage": {
+            "label": "struct IYieldStreamerTypes.RateTier",
+            "members": [
+              {
+                "label": "rate",
+                "type": "t_uint48",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "cap",
+                "type": "t_uint64",
+                "offset": 6,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldRate)2851_storage": {
+            "label": "struct IYieldStreamerTypes.YieldRate",
+            "members": [
+              {
+                "label": "tiers",
+                "type": "t_array(t_struct(RateTier)2857_storage)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldState)2869_storage": {
+            "label": "struct IYieldStreamerTypes.YieldState",
+            "members": [
+              {
+                "label": "flags",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "streamYield",
+                "type": "t_uint64",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "accruedYield",
+                "type": "t_uint64",
+                "offset": 9,
+                "slot": "0"
+              },
+              {
+                "label": "lastUpdateTimestamp",
+                "type": "t_uint40",
+                "offset": 17,
+                "slot": "0"
+              },
+              {
+                "label": "lastUpdateBalance",
+                "type": "t_uint64",
+                "offset": 22,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldStreamerHarnessLayout)3030_storage": {
+            "label": "struct YieldStreamerHarness.YieldStreamerHarnessLayout",
+            "members": [
+              {
+                "label": "currentBlockTimestamp",
+                "type": "t_uint40",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "usingSpecialBlockTimestamps",
+                "type": "t_bool",
+                "offset": 5,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldStreamerInitializationStorageLayout)2367_storage": {
+            "label": "struct YieldStreamerStorage_Initialization.YieldStreamerInitializationStorageLayout",
+            "members": [
+              {
+                "label": "sourceYieldStreamer",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "groupIds",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldStreamerStorageLayout)2404_storage": {
+            "label": "struct YieldStreamerStorage_Primary.YieldStreamerStorageLayout",
+            "members": [
+              {
+                "label": "underlyingToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "feeReceiver",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "groups",
+                "type": "t_mapping(t_address,t_struct(Group)2843_storage)",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "yieldStates",
+                "type": "t_mapping(t_address,t_struct(YieldState)2869_storage)",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "yieldRates",
+                "type": "t_mapping(t_uint32,t_array(t_struct(YieldRate)2851_storage)dyn_storage)",
+                "offset": 0,
+                "slot": "4"
+              }
+            ],
+            "numberOfBytes": "160"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint40": {
+            "label": "uint40",
+            "numberOfBytes": "5"
+          },
+          "t_uint48": {
+            "label": "uint48",
+            "numberOfBytes": "6"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:cloudwalk.yieldstreamer.harness.storage": [
+            {
+              "contract": "YieldStreamerHarness",
+              "label": "currentBlockTimestamp",
+              "type": "t_uint40",
+              "src": "contracts\\testable\\YieldStreamerHarness.sol:32",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerHarness",
+              "label": "usingSpecialBlockTimestamps",
+              "type": "t_bool",
+              "src": "contracts\\testable\\YieldStreamerHarness.sol:33",
+              "offset": 5,
+              "slot": "0"
+            }
+          ],
+          "erc7201:cloudwalk.yieldstreamer.initialization.storage": [
+            {
+              "contract": "YieldStreamerStorage_Initialization",
+              "label": "sourceYieldStreamer",
+              "type": "t_address",
+              "src": "contracts\\YieldStreamerStorage.sol:72",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerStorage_Initialization",
+              "label": "groupIds",
+              "type": "t_mapping(t_bytes32,t_uint256)",
+              "src": "contracts\\YieldStreamerStorage.sol:73",
+              "offset": 0,
+              "slot": "1"
+            }
+          ],
+          "erc7201:cloudwalk.yieldstreamer.primary.storage": [
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "underlyingToken",
+              "type": "t_address",
+              "src": "contracts\\YieldStreamerStorage.sol:120",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "feeReceiver",
+              "type": "t_address",
+              "src": "contracts\\YieldStreamerStorage.sol:121",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "groups",
+              "type": "t_mapping(t_address,t_struct(Group)2843_storage)",
+              "src": "contracts\\YieldStreamerStorage.sol:122",
+              "offset": 0,
+              "slot": "2"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "yieldStates",
+              "type": "t_mapping(t_address,t_struct(YieldState)2869_storage)",
+              "src": "contracts\\YieldStreamerStorage.sol:123",
+              "offset": 0,
+              "slot": "3"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "yieldRates",
+              "type": "t_mapping(t_uint32,t_array(t_struct(YieldRate)2851_storage)dyn_storage)",
+              "src": "contracts\\YieldStreamerStorage.sol:124",
+              "offset": 0,
+              "slot": "4"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\utils\\PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/unknown-2009.json
+++ b/.openzeppelin/unknown-2009.json
@@ -387,6 +387,766 @@
           ]
         }
       }
+    },
+    "ceb2b96a83d1786ee42a15badeb43cd798d7d1f94e201523c4aedbb62ae6198a": {
+      "address": "0xf333c1fbd5AE6d4f72254f617649a124643f609B",
+      "txHash": "0x5f19a626f0c7049cab872a4f2348a0413b59d560610316fd2db517f2e338e5a1",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(RateTier)2857_storage)dyn_storage": {
+            "label": "struct IYieldStreamerTypes.RateTier[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(YieldRate)2851_storage)dyn_storage": {
+            "label": "struct IYieldStreamerTypes.YieldRate[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Group)2843_storage)": {
+            "label": "mapping(address => struct IYieldStreamerTypes.Group)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(YieldState)2869_storage)": {
+            "label": "mapping(address => struct IYieldStreamerTypes.YieldState)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint32,t_array(t_struct(YieldRate)2851_storage)dyn_storage)": {
+            "label": "mapping(uint32 => struct IYieldStreamerTypes.YieldRate[])",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Group)2843_storage": {
+            "label": "struct IYieldStreamerTypes.Group",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_uint32",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)145_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)291_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RateTier)2857_storage": {
+            "label": "struct IYieldStreamerTypes.RateTier",
+            "members": [
+              {
+                "label": "rate",
+                "type": "t_uint48",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "cap",
+                "type": "t_uint64",
+                "offset": 6,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldRate)2851_storage": {
+            "label": "struct IYieldStreamerTypes.YieldRate",
+            "members": [
+              {
+                "label": "tiers",
+                "type": "t_array(t_struct(RateTier)2857_storage)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldState)2869_storage": {
+            "label": "struct IYieldStreamerTypes.YieldState",
+            "members": [
+              {
+                "label": "flags",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "streamYield",
+                "type": "t_uint64",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "accruedYield",
+                "type": "t_uint64",
+                "offset": 9,
+                "slot": "0"
+              },
+              {
+                "label": "lastUpdateTimestamp",
+                "type": "t_uint40",
+                "offset": 17,
+                "slot": "0"
+              },
+              {
+                "label": "lastUpdateBalance",
+                "type": "t_uint64",
+                "offset": 22,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldStreamerInitializationStorageLayout)2367_storage": {
+            "label": "struct YieldStreamerStorage_Initialization.YieldStreamerInitializationStorageLayout",
+            "members": [
+              {
+                "label": "sourceYieldStreamer",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "groupIds",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldStreamerStorageLayout)2404_storage": {
+            "label": "struct YieldStreamerStorage_Primary.YieldStreamerStorageLayout",
+            "members": [
+              {
+                "label": "underlyingToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "feeReceiver",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "groups",
+                "type": "t_mapping(t_address,t_struct(Group)2843_storage)",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "yieldStates",
+                "type": "t_mapping(t_address,t_struct(YieldState)2869_storage)",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "yieldRates",
+                "type": "t_mapping(t_uint32,t_array(t_struct(YieldRate)2851_storage)dyn_storage)",
+                "offset": 0,
+                "slot": "4"
+              }
+            ],
+            "numberOfBytes": "160"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint40": {
+            "label": "uint40",
+            "numberOfBytes": "5"
+          },
+          "t_uint48": {
+            "label": "uint48",
+            "numberOfBytes": "6"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:cloudwalk.yieldstreamer.initialization.storage": [
+            {
+              "contract": "YieldStreamerStorage_Initialization",
+              "label": "sourceYieldStreamer",
+              "type": "t_address",
+              "src": "contracts\\YieldStreamerStorage.sol:72",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerStorage_Initialization",
+              "label": "groupIds",
+              "type": "t_mapping(t_bytes32,t_uint256)",
+              "src": "contracts\\YieldStreamerStorage.sol:73",
+              "offset": 0,
+              "slot": "1"
+            }
+          ],
+          "erc7201:cloudwalk.yieldstreamer.primary.storage": [
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "underlyingToken",
+              "type": "t_address",
+              "src": "contracts\\YieldStreamerStorage.sol:120",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "feeReceiver",
+              "type": "t_address",
+              "src": "contracts\\YieldStreamerStorage.sol:121",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "groups",
+              "type": "t_mapping(t_address,t_struct(Group)2843_storage)",
+              "src": "contracts\\YieldStreamerStorage.sol:122",
+              "offset": 0,
+              "slot": "2"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "yieldStates",
+              "type": "t_mapping(t_address,t_struct(YieldState)2869_storage)",
+              "src": "contracts\\YieldStreamerStorage.sol:123",
+              "offset": 0,
+              "slot": "3"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "yieldRates",
+              "type": "t_mapping(t_uint32,t_array(t_struct(YieldRate)2851_storage)dyn_storage)",
+              "src": "contracts\\YieldStreamerStorage.sol:124",
+              "offset": 0,
+              "slot": "4"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\utils\\PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "4d931d8217cde2cd4c6fd76d5657cd1668e3bd708c6ede6513895dbb42f9ff4f": {
+      "address": "0xE4225A469EDF0e2dc3c0Fbff01945962534512F3",
+      "txHash": "0x26af2555fa92dcedc828edce994a49f009aa2c27406f69e7c0f9bc449058d2ea",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(RateTier)2857_storage)dyn_storage": {
+            "label": "struct IYieldStreamerTypes.RateTier[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(YieldRate)2851_storage)dyn_storage": {
+            "label": "struct IYieldStreamerTypes.YieldRate[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Group)2843_storage)": {
+            "label": "mapping(address => struct IYieldStreamerTypes.Group)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(YieldState)2869_storage)": {
+            "label": "mapping(address => struct IYieldStreamerTypes.YieldState)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint32,t_array(t_struct(YieldRate)2851_storage)dyn_storage)": {
+            "label": "mapping(uint32 => struct IYieldStreamerTypes.YieldRate[])",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Group)2843_storage": {
+            "label": "struct IYieldStreamerTypes.Group",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_uint32",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)145_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)291_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RateTier)2857_storage": {
+            "label": "struct IYieldStreamerTypes.RateTier",
+            "members": [
+              {
+                "label": "rate",
+                "type": "t_uint48",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "cap",
+                "type": "t_uint64",
+                "offset": 6,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldRate)2851_storage": {
+            "label": "struct IYieldStreamerTypes.YieldRate",
+            "members": [
+              {
+                "label": "tiers",
+                "type": "t_array(t_struct(RateTier)2857_storage)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldState)2869_storage": {
+            "label": "struct IYieldStreamerTypes.YieldState",
+            "members": [
+              {
+                "label": "flags",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "streamYield",
+                "type": "t_uint64",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "accruedYield",
+                "type": "t_uint64",
+                "offset": 9,
+                "slot": "0"
+              },
+              {
+                "label": "lastUpdateTimestamp",
+                "type": "t_uint40",
+                "offset": 17,
+                "slot": "0"
+              },
+              {
+                "label": "lastUpdateBalance",
+                "type": "t_uint64",
+                "offset": 22,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldStreamerInitializationStorageLayout)2367_storage": {
+            "label": "struct YieldStreamerStorage_Initialization.YieldStreamerInitializationStorageLayout",
+            "members": [
+              {
+                "label": "sourceYieldStreamer",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "groupIds",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(YieldStreamerStorageLayout)2404_storage": {
+            "label": "struct YieldStreamerStorage_Primary.YieldStreamerStorageLayout",
+            "members": [
+              {
+                "label": "underlyingToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "feeReceiver",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "groups",
+                "type": "t_mapping(t_address,t_struct(Group)2843_storage)",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "yieldStates",
+                "type": "t_mapping(t_address,t_struct(YieldState)2869_storage)",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "yieldRates",
+                "type": "t_mapping(t_uint32,t_array(t_struct(YieldRate)2851_storage)dyn_storage)",
+                "offset": 0,
+                "slot": "4"
+              }
+            ],
+            "numberOfBytes": "160"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint40": {
+            "label": "uint40",
+            "numberOfBytes": "5"
+          },
+          "t_uint48": {
+            "label": "uint48",
+            "numberOfBytes": "6"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:cloudwalk.yieldstreamer.initialization.storage": [
+            {
+              "contract": "YieldStreamerStorage_Initialization",
+              "label": "sourceYieldStreamer",
+              "type": "t_address",
+              "src": "contracts\\YieldStreamerStorage.sol:72",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerStorage_Initialization",
+              "label": "groupIds",
+              "type": "t_mapping(t_bytes32,t_uint256)",
+              "src": "contracts\\YieldStreamerStorage.sol:73",
+              "offset": 0,
+              "slot": "1"
+            }
+          ],
+          "erc7201:cloudwalk.yieldstreamer.primary.storage": [
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "underlyingToken",
+              "type": "t_address",
+              "src": "contracts\\YieldStreamerStorage.sol:120",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "feeReceiver",
+              "type": "t_address",
+              "src": "contracts\\YieldStreamerStorage.sol:121",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "groups",
+              "type": "t_mapping(t_address,t_struct(Group)2843_storage)",
+              "src": "contracts\\YieldStreamerStorage.sol:122",
+              "offset": 0,
+              "slot": "2"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "yieldStates",
+              "type": "t_mapping(t_address,t_struct(YieldState)2869_storage)",
+              "src": "contracts\\YieldStreamerStorage.sol:123",
+              "offset": 0,
+              "slot": "3"
+            },
+            {
+              "contract": "YieldStreamerStorage_Primary",
+              "label": "yieldRates",
+              "type": "t_mapping(t_uint32,t_array(t_struct(YieldRate)2851_storage)dyn_storage)",
+              "src": "contracts\\YieldStreamerStorage.sol:124",
+              "offset": 0,
+              "slot": "4"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\utils\\PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Main changes

1. The `YieldStreamerHarness` contract has been upgraded in Testnet.
2. The `YieldStreamer` contract has been upgraded in Mainnet.
3. The `.openzeppelin` network files have been updated accordingly