### PR TITLE
feat: remove explicit rounding from `getClaimPreview` function

### DIFF
--- a/contracts/YieldStreamer.sol
+++ b/contracts/YieldStreamer.sol
@@ -119,8 +119,8 @@ contract YieldStreamer is
     /**
      * @inheritdoc IYieldStreamerPrimary_Functions
      */
-    function getClaimPreview(address account, bool round) external view returns (ClaimPreview memory) {
-        return _getClaimPreview(account, _blockTimestamp(), round);
+    function getClaimPreview(address account) external view returns (ClaimPreview memory) {
+        return _getClaimPreview(account, _blockTimestamp());
     }
 
     /**

--- a/contracts/YieldStreamerPrimary.sol
+++ b/contracts/YieldStreamerPrimary.sol
@@ -253,11 +253,11 @@ abstract contract YieldStreamerPrimary is
      * @param account The account to get the claim preview for.
      * @return A `ClaimPreview` struct containing details of the claimable yield.
      */
-    function _getClaimPreview(address account, uint256 currentTimestamp, bool round) internal view returns (ClaimPreview memory) {
+    function _getClaimPreview(address account, uint256 currentTimestamp) internal view returns (ClaimPreview memory) {
         YieldStreamerStorageLayout storage $ = _yieldStreamerStorage();
         YieldState storage state = $.yieldStates[account];
         YieldRate[] storage rates = $.yieldRates[$.groups[account].id];
-        return _map(_getAccruePreview(state, rates, currentTimestamp), round);
+        return _map(_getAccruePreview(state, rates, currentTimestamp));
     }
 
     /**
@@ -1031,13 +1031,14 @@ abstract contract YieldStreamerPrimary is
      * @dev Maps an `AccruePreview` struct to a `ClaimPreview` struct.
      *
      * @param accruePreview The `AccruePreview` struct to map from.
-     * @param round Whether to round the yield and fee amounts.
      * @return claimPreview The resulting `ClaimPreview` struct.
      */
-    function _map(AccruePreview memory accruePreview, bool round) internal pure returns (ClaimPreview memory claimPreview) {
+    function _map(AccruePreview memory accruePreview) internal pure returns (ClaimPreview memory claimPreview) {
         uint256 totalYield = accruePreview.accruedYieldAfter + accruePreview.streamYieldAfter;
-        claimPreview.yield = round ? _roundDown(totalYield) : totalYield;
-        claimPreview.fee = 0; // Fees are not supported yet.
+        claimPreview.yieldExact = totalYield;
+        claimPreview.yieldRounded = _roundDown(totalYield);
+        claimPreview.feeExact = 0; // Fees are not supported yet.
+        claimPreview.feeRounded = 0; // Fees are not supported yet.
         claimPreview.timestamp = accruePreview.toTimestamp;
         claimPreview.balance = accruePreview.balance;
 

--- a/contracts/base/Versionable.sol
+++ b/contracts/base/Versionable.sol
@@ -16,6 +16,6 @@ abstract contract Versionable is IVersionable {
      * @inheritdoc IVersionable
      */
     function $__VERSION() external pure returns (Version memory) {
-        return Version(2, 1, 0);
+        return Version(2, 2, 0);
     }
 }

--- a/contracts/interfaces/IYieldStreamerPrimary.sol
+++ b/contracts/interfaces/IYieldStreamerPrimary.sol
@@ -110,13 +110,9 @@ interface IYieldStreamerPrimary_Functions {
      * Estimates the yield amount that can be claimed without modifying the contract state.
      *
      * @param account The address of the account to query.
-     * @param round Whether to round the yield and fee amounts.
      * @return A `ClaimPreview` struct containing details of the claimable yield.
      */
-    function getClaimPreview(
-        address account,
-        bool round
-    ) external view returns (IYieldStreamerTypes.ClaimPreview memory);
+    function getClaimPreview(address account) external view returns (IYieldStreamerTypes.ClaimPreview memory);
 
     /**
      * @dev Provides a preview of the yield accrual for a given account over time.

--- a/contracts/interfaces/IYieldStreamerTypes.sol
+++ b/contracts/interfaces/IYieldStreamerTypes.sol
@@ -84,16 +84,20 @@ interface IYieldStreamerTypes {
      * Used to estimate the yield that can be claimed without modifying the contract state.
      *
      * Fields:
-     * - `yield`: The total claimable yield amount available for the account.
-     * - `fee`: The fee amount that would be deducted during the claim.
+     * - `yieldExact`: The total claimable yield amount available for the account (without rounding).
+     * - `feeExact`: The fee amount that would be deducted during the claim (without rounding).
+     * - `yieldRounded`: The total claimable yield amount available for the account (rounded).
+     * - `feeRounded`: The fee amount that would be deducted during the claim (rounded).
      * - `timestamp`: The timestamp at which the preview was calculated.
      * - `balance`: The account's token balance used in the calculation.
      * - `rates`: The current yield rates applicable to the account.
      * - `caps`: The current rate caps applicable to the account.
      */
     struct ClaimPreview {
-        uint256 yield;
-        uint256 fee;
+        uint256 yieldExact;
+        uint256 feeExact;
+        uint256 yieldRounded;
+        uint256 feeRounded;
         uint256 timestamp;
         uint256 balance;
         uint256[] rates;

--- a/contracts/testable/YieldStreamerTestable.sol
+++ b/contracts/testable/YieldStreamerTestable.sol
@@ -88,7 +88,7 @@ contract YieldStreamerTestable is YieldStreamer {
         return _roundUp(amount);
     }
 
-    function map(AccruePreview memory accrue, bool round) external pure returns (ClaimPreview memory) {
-        return _map(accrue, round);
+    function map(AccruePreview memory accrue) external pure returns (ClaimPreview memory) {
+        return _map(accrue);
     }
 }

--- a/test/YieldStreamer.schedule.test.ts
+++ b/test/YieldStreamer.schedule.test.ts
@@ -173,7 +173,7 @@ describe("YieldStreamer - Deposit/Withdraw Simulation Tests", function () {
   let adjustedBlockTime: number;
   const EXPECTED_VERSION: Version = {
     major: 2,
-    minor: 1,
+    minor: 2,
     patch: 0
   };
 

--- a/test/YieldStreamerHarness.test.ts
+++ b/test/YieldStreamerHarness.test.ts
@@ -77,7 +77,7 @@ describe("YieldStreamerHarness", function () {
   const harnessAdminRole: string = ethers.id("HARNESS_ADMIN_ROLE");
   const EXPECTED_VERSION: Version = {
     major: 2,
-    minor: 1,
+    minor: 2,
     patch: 0
   };
 

--- a/test/YieldStreamerTestable.test.ts
+++ b/test/YieldStreamerTestable.test.ts
@@ -55,8 +55,10 @@ interface AccruePreview {
 }
 
 interface ClaimPreview {
-  yield: bigint;
-  fee: bigint;
+  yieldExact: bigint;
+  yieldRounded: bigint;
+  feeExact: bigint;
+  feeRounded: bigint;
   timestamp: bigint;
   balance: bigint;
   rates: bigint[];
@@ -2335,17 +2337,19 @@ describe("YieldStreamerTestable", async () => {
       ]
     };
 
-    it("Should map as expected (rounded)", async () => {
+    it("Should map as expected", async () => {
       const { yieldStreamerTestable } = await setUpFixture(deployContracts);
 
       // Call the `map` function
-      const claimPreviewRaw: ClaimPreview = await yieldStreamerTestable.map(accruePreview, true);
+      const claimPreviewRaw: ClaimPreview = await yieldStreamerTestable.map(accruePreview);
 
       // Create the `ClaimPreview` struct with expected values
       const expectedClaimPreview: ClaimPreview = {
-        yield: roundDown(accruePreview.accruedYieldAfter + accruePreview.streamYieldAfter),
+        yieldExact: accruePreview.accruedYieldAfter + accruePreview.streamYieldAfter,
+        yieldRounded: roundDown(accruePreview.accruedYieldAfter + accruePreview.streamYieldAfter),
+        feeExact: 0n,
+        feeRounded: 0n,
         balance: accruePreview.balance,
-        fee: 0n,
         timestamp: accruePreview.toTimestamp,
         rates: accruePreview.rates[accruePreview.rates.length - 1].tiers.map(tier => tier.rate),
         caps: accruePreview.rates[accruePreview.rates.length - 1].tiers.map(tier => tier.cap)
@@ -2355,36 +2359,10 @@ describe("YieldStreamerTestable", async () => {
       expect(accruePreview.accruedYieldAfter + accruePreview.streamYieldAfter).not.to.equal(
         roundDown(accruePreview.accruedYieldAfter + accruePreview.streamYieldAfter)
       );
-      expect(expectedClaimPreview.yield).to.equal(claimPreviewRaw.yield);
-      expect(expectedClaimPreview.fee).to.equal(claimPreviewRaw.fee);
-      expect(expectedClaimPreview.timestamp).to.equal(claimPreviewRaw.timestamp);
-      expect(expectedClaimPreview.balance).to.equal(claimPreviewRaw.balance);
-      expect(expectedClaimPreview.rates).to.deep.equal(claimPreviewRaw.rates);
-      expect(expectedClaimPreview.caps).to.deep.equal(claimPreviewRaw.caps);
-    });
-
-    it("Should map as expected (not rounded)", async () => {
-      const { yieldStreamerTestable } = await setUpFixture(deployContracts);
-
-      // Call the `map` function
-      const claimPreviewRaw: ClaimPreview = await yieldStreamerTestable.map(accruePreview, false);
-
-      // Create the `ClaimPreview` struct with expected values
-      const expectedClaimPreview: ClaimPreview = {
-        yield: accruePreview.accruedYieldAfter + accruePreview.streamYieldAfter,
-        balance: accruePreview.balance,
-        fee: 0n,
-        timestamp: accruePreview.toTimestamp,
-        rates: accruePreview.rates[accruePreview.rates.length - 1].tiers.map(tier => tier.rate),
-        caps: accruePreview.rates[accruePreview.rates.length - 1].tiers.map(tier => tier.cap)
-      };
-
-      // Assertion
-      expect(accruePreview.accruedYieldAfter + accruePreview.streamYieldAfter).not.to.equal(
-        roundDown(accruePreview.accruedYieldAfter + accruePreview.streamYieldAfter)
-      );
-      expect(expectedClaimPreview.yield).to.equal(claimPreviewRaw.yield);
-      expect(expectedClaimPreview.fee).to.equal(claimPreviewRaw.fee);
+      expect(expectedClaimPreview.yieldExact).to.equal(claimPreviewRaw.yieldExact);
+      expect(expectedClaimPreview.yieldRounded).to.equal(claimPreviewRaw.yieldRounded);
+      expect(expectedClaimPreview.feeExact).to.equal(claimPreviewRaw.feeExact);
+      expect(expectedClaimPreview.feeRounded).to.equal(claimPreviewRaw.feeRounded);
       expect(expectedClaimPreview.timestamp).to.equal(claimPreviewRaw.timestamp);
       expect(expectedClaimPreview.balance).to.equal(claimPreviewRaw.balance);
       expect(expectedClaimPreview.rates).to.deep.equal(claimPreviewRaw.rates);


### PR DESCRIPTION
## Main changes

1. The `getClaimPreview` function has been updated by removing a `bool round` parameter:
```Solidity
    /**
     * @dev Provides a preview of the claimable yield for a given account at the current time.
     * Estimates the yield amount that can be claimed without modifying the contract state.
     *
     * @param account The address of the account to query.
     * @return A `ClaimPreview` struct containing details of the claimable yield.
     */
    function getClaimPreview(address account) external view returns (IYieldStreamerTypes.ClaimPreview memory);
```
2. The `ClaimPreview` has been extended by adding `Exact` and `Rounded` groups of fields:
```Solidity
    /**
     * @dev Structure representing a preview of the claimable yield for an account.
     * Used to estimate the yield that can be claimed without modifying the contract state.
     *
     * Fields:
     * - `yieldExact`: The total claimable yield amount available for the account (without rounding).
     * - `feeExact`: The fee amount that would be deducted during the claim (without rounding).
     * - `yieldRounded`: The total claimable yield amount available for the account (rounded).
     * - `feeRounded`: The fee amount that would be deducted during the claim (rounded).
     * - `timestamp`: The timestamp at which the preview was calculated.
     * - `balance`: The account's token balance used in the calculation.
     * - `rates`: The current yield rates applicable to the account.
     * - `caps`: The current rate caps applicable to the account.
     */
    struct ClaimPreview {
        uint256 yieldExact;
        uint256 feeExact;
        uint256 yieldRounded;
        uint256 feeRounded;
        uint256 timestamp;
        uint256 balance;
        uint256[] rates;
        uint256[] caps;
    }
```

### Contract version
The contract version was updated from `v2.1.0` to `2.2.0`.

### Test coverage
The changes are fully covered by the tests.