### PR TITLE
feat: add ability to archive contract and reset yield balances

### DIFF
--- a/contracts/YieldStreamer.sol
+++ b/contracts/YieldStreamer.sol
@@ -110,6 +110,20 @@ contract YieldStreamer is
     }
 
     /**
+     * @inheritdoc IYieldStreamerConfiguration_Functions
+     */
+    function setIsArchived(bool isArchived_) external onlyRole(OWNER_ROLE) {
+        _setIsArchived(isArchived_);
+    }
+
+    /**
+     * @inheritdoc IYieldStreamerPrimary_Functions
+     */
+    function isArchived() external view returns (bool) {
+        return _yieldStreamerStorage().isArchived;
+    }
+
+    /**
      * @inheritdoc IYieldStreamerPrimary_Functions
      */
     function getYieldState(address account) external view returns (YieldState memory) {

--- a/contracts/YieldStreamerConfiguration.sol
+++ b/contracts/YieldStreamerConfiguration.sol
@@ -25,6 +25,23 @@ abstract contract YieldStreamerConfiguration is
     // ------------------ Functions ------------------------------- //
 
     /**
+     * @dev Sets the archived state of the yield streamer contract.
+     *
+     * Emits an {IsArchivedChanged} event
+     *
+     * @param isArchived_ The flag that indicates if the yield streamer is archived.
+     */
+    function _setIsArchived(bool isArchived_) internal {
+        if (_yieldStreamerStorage().isArchived && isArchived_) {
+            revert YieldStreamer_ContractAlreadyArchived();
+        }
+
+        _yieldStreamerStorage().isArchived = isArchived_;
+
+        emit YieldStreamer_IsArchivedChanged(isArchived_);
+    }
+
+    /**
     //  * @dev Adds a new yield rate entry for a specific group.
     //  * The yield rate becomes effective starting from the specified effective day.
     //  * The `effectiveDay` represents the day index since the Unix epoch (i.e., number of days since timestamp zero).

--- a/contracts/YieldStreamerPrimary.sol
+++ b/contracts/YieldStreamerPrimary.sol
@@ -294,7 +294,11 @@ abstract contract YieldStreamerPrimary is
         YieldState memory state,
         YieldRate[] memory rates,
         uint256 currentTimestamp
-    ) public pure returns (AccruePreview memory) {
+    ) public view returns (AccruePreview memory) {
+        if (_yieldStreamerStorage().isArchived) {
+            return AccruePreview(0, 0, 0, 0, 0, 0, 0, new YieldRate[](0), new YieldResult[](0));
+        }
+
         AccruePreview memory preview;
 
         preview.balance = state.lastUpdateBalance;

--- a/contracts/YieldStreamerPrimary.sol
+++ b/contracts/YieldStreamerPrimary.sol
@@ -254,6 +254,10 @@ abstract contract YieldStreamerPrimary is
      * @return A `ClaimPreview` struct containing details of the claimable yield.
      */
     function _getClaimPreview(address account, uint256 currentTimestamp) internal view returns (ClaimPreview memory) {
+        if (_yieldStreamerStorage().isArchived) {
+            return ClaimPreview(0, 0, 0, 0, 0, 0, new uint256[](0), new uint256[](0));
+        }
+
         YieldStreamerStorageLayout storage $ = _yieldStreamerStorage();
         YieldState storage state = $.yieldStates[account];
         YieldRate[] storage rates = $.yieldRates[$.groups[account].id];
@@ -268,6 +272,10 @@ abstract contract YieldStreamerPrimary is
      * @return An `AccruePreview` struct containing details of the accrued yield.
      */
     function _getAccruePreview(address account, uint256 currentTimestamp) internal view returns (AccruePreview memory) {
+        if (_yieldStreamerStorage().isArchived) {
+            return AccruePreview(0, 0, 0, 0, 0, 0, 0, new YieldRate[](0), new YieldResult[](0));
+        }
+
         YieldStreamerStorageLayout storage $ = _yieldStreamerStorage();
         YieldState storage state = $.yieldStates[account];
         YieldRate[] storage rates = $.yieldRates[$.groups[account].id];

--- a/contracts/YieldStreamerPrimary.sol
+++ b/contracts/YieldStreamerPrimary.sol
@@ -254,10 +254,6 @@ abstract contract YieldStreamerPrimary is
      * @return A `ClaimPreview` struct containing details of the claimable yield.
      */
     function _getClaimPreview(address account, uint256 currentTimestamp) internal view returns (ClaimPreview memory) {
-        if (_yieldStreamerStorage().isArchived) {
-            return ClaimPreview(0, 0, 0, 0, 0, 0, new uint256[](0), new uint256[](0));
-        }
-
         YieldStreamerStorageLayout storage $ = _yieldStreamerStorage();
         YieldState storage state = $.yieldStates[account];
         YieldRate[] storage rates = $.yieldRates[$.groups[account].id];
@@ -272,10 +268,6 @@ abstract contract YieldStreamerPrimary is
      * @return An `AccruePreview` struct containing details of the accrued yield.
      */
     function _getAccruePreview(address account, uint256 currentTimestamp) internal view returns (AccruePreview memory) {
-        if (_yieldStreamerStorage().isArchived) {
-            return AccruePreview(0, 0, 0, 0, 0, 0, 0, new YieldRate[](0), new YieldResult[](0));
-        }
-
         YieldStreamerStorageLayout storage $ = _yieldStreamerStorage();
         YieldState storage state = $.yieldStates[account];
         YieldRate[] storage rates = $.yieldRates[$.groups[account].id];
@@ -1054,17 +1046,19 @@ abstract contract YieldStreamerPrimary is
         claimPreview.timestamp = accruePreview.toTimestamp;
         claimPreview.balance = accruePreview.balance;
 
-        uint256 lastRateIndex = accruePreview.rates.length - 1;
-        uint256 lastRateLength = accruePreview.rates[lastRateIndex].tiers.length;
-        uint256[] memory rates = new uint256[](lastRateLength);
-        uint256[] memory caps = new uint256[](lastRateLength);
-        for (uint256 i = 0; i < lastRateLength; ++i) {
-            rates[i] = accruePreview.rates[lastRateIndex].tiers[i].rate;
-            caps[i] = accruePreview.rates[lastRateIndex].tiers[i].cap;
-        }
+        if (accruePreview.rates.length > 0) {
+            uint256 lastRateIndex = accruePreview.rates.length - 1;
+            uint256 lastRateLength = accruePreview.rates[lastRateIndex].tiers.length;
+            uint256[] memory rates = new uint256[](lastRateLength);
+            uint256[] memory caps = new uint256[](lastRateLength);
+            for (uint256 i = 0; i < lastRateLength; ++i) {
+                rates[i] = accruePreview.rates[lastRateIndex].tiers[i].rate;
+                caps[i] = accruePreview.rates[lastRateIndex].tiers[i].cap;
+            }
 
-        claimPreview.rates = rates;
-        claimPreview.caps = caps;
+            claimPreview.rates = rates;
+            claimPreview.caps = caps;
+        }
     }
 
     // ------------------ Overrides ------------------------------- //

--- a/contracts/YieldStreamerStorage.sol
+++ b/contracts/YieldStreamerStorage.sol
@@ -113,6 +113,7 @@ contract YieldStreamerStorage_Primary is IYieldStreamerTypes {
      * - `groups`: A mapping from account addresses to their assigned group.
      * - `yieldStates`: A mapping from account addresses to their yield state.
      * - `yieldRates`: A mapping from group IDs to arrays of yield rates applied to that group.
+     * - `isArchived`: A flag indicating whether the yield streamer is archived (all yield is zeroed out).
      *
      * @custom:storage-location erc7201:cloudwalk.yieldstreamer.primary.storage
      */
@@ -122,6 +123,7 @@ contract YieldStreamerStorage_Primary is IYieldStreamerTypes {
         mapping(address => Group) groups;
         mapping(address => YieldState) yieldStates;
         mapping(uint32 => YieldRate[]) yieldRates;
+        bool isArchived;
     }
 
     /**

--- a/contracts/base/Versionable.sol
+++ b/contracts/base/Versionable.sol
@@ -16,6 +16,6 @@ abstract contract Versionable is IVersionable {
      * @inheritdoc IVersionable
      */
     function $__VERSION() external pure returns (Version memory) {
-        return Version(2, 2, 0);
+        return Version(2, 3, 0);
     }
 }

--- a/contracts/interfaces/IYieldStreamerConfiguration.sol
+++ b/contracts/interfaces/IYieldStreamerConfiguration.sol
@@ -22,6 +22,9 @@ interface IYieldStreamerConfiguration_Errors {
 
     /// @dev Thrown when attempting to assign an account to a group it is already assigned to.
     error YieldStreamer_GroupAlreadyAssigned(address account);
+
+    /// @dev Thrown when the yield streamer contract is already archived.
+    error YieldStreamer_ContractAlreadyArchived();
 }
 
 /**
@@ -85,6 +88,13 @@ interface IYieldStreamerConfiguration_Events {
         address indexed newFeeReceiver, // Tools: this comment prevents Prettier from formatting into a single line.
         address indexed oldFeeReceiver
     );
+
+    /**
+     * @dev Emitted when the archived state of the yield streamer contract is changed.
+     *
+     * @param isArchived The new archived state of the yield streamer contract.
+     */
+    event YieldStreamer_IsArchivedChanged(bool isArchived);
 }
 
 /**
@@ -93,6 +103,14 @@ interface IYieldStreamerConfiguration_Events {
  * @dev Defines the function signatures for the yield streamer configuration contract.
  */
 interface IYieldStreamerConfiguration_Functions {
+    /**
+     * @dev Sets the archived state of the yield streamer contract.
+     * When archived, yield calculation functions return zeroed values.
+     *
+     * @param isArchived If true, the yield streamer is considered archived.
+     */
+    function setIsArchived(bool isArchived) external;
+
     /**
      * @dev Adds a new yield rate for a specific group.
      * The yield rate becomes effective starting from the specified effective day.

--- a/contracts/interfaces/IYieldStreamerPrimary.sol
+++ b/contracts/interfaces/IYieldStreamerPrimary.sol
@@ -97,6 +97,11 @@ interface IYieldStreamerPrimary_Functions {
     function claimAmountFor(address account, uint256 amount) external;
 
     /**
+     * @dev Returns true if the streamer is archived (all yield is zeroed out).
+     */
+    function isArchived() external view returns (bool);
+
+    /**
      * @dev Retrieves the current yield state for a given account.
      * Provides information about the account's yield accrual and balances.
      *

--- a/contracts/testable/YieldStreamerTestable.sol
+++ b/contracts/testable/YieldStreamerTestable.sol
@@ -45,7 +45,7 @@ contract YieldStreamerTestable is YieldStreamer {
         YieldState memory state,
         YieldRate[] memory rates,
         uint256 currentTimestamp
-    ) external pure returns (AccruePreview memory) {
+    ) external view returns (AccruePreview memory) {
         return _getAccruePreview(state, rates, currentTimestamp);
     }
 

--- a/test-utils/specific.ts
+++ b/test-utils/specific.ts
@@ -10,6 +10,7 @@ export const ERRORS = {
   YieldStreamer_AccountNotInitialized: "YieldStreamer_AccountNotInitialized",
   YieldStreamer_ClaimAmountBelowMinimum: "YieldStreamer_ClaimAmountBelowMinimum",
   YieldStreamer_ClaimAmountNonRounded: "YieldStreamer_ClaimAmountNonRounded",
+  YieldStreamer_ContractAlreadyArchived: "YieldStreamer_ContractAlreadyArchived",
   YieldStreamer_EmptyArray: "YieldStreamer_EmptyArray",
   YieldStreamer_FeeReceiverAlreadyConfigured: "YieldStreamer_FeeReceiverAlreadyConfigured",
   YieldStreamer_GroupAlreadyAssigned: "YieldStreamer_GroupAlreadyAssigned",

--- a/test/YieldStreamer.external.test.ts
+++ b/test/YieldStreamer.external.test.ts
@@ -2311,7 +2311,7 @@ describe("Contract 'YieldStreamer' regarding external functions", async () => {
       const previewBeforeRaw = await yieldStreamer.getClaimPreview(users[0].address);
       const previewBefore = normalizeClaimPreview(previewBeforeRaw);
 
-      expect(previewBefore).to.include({ balance: nonZeroState.lastUpdateBalance});
+      expect(previewBefore).to.include({ balance: nonZeroState.lastUpdateBalance });
       expect(previewBefore.rates.length).to.be.greaterThan(0);
       expect(previewBefore.caps.length).to.be.greaterThan(0);
       expect(previewBefore.yieldExact).to.be.greaterThanOrEqual(nonZeroState.accruedYield + nonZeroState.streamYield);

--- a/test/YieldStreamer.external.test.ts
+++ b/test/YieldStreamer.external.test.ts
@@ -172,7 +172,7 @@ interface Fixture {
 
 const EXPECTED_VERSION: Version = {
   major: 2,
-  minor: 2,
+  minor: 3,
   patch: 0
 };
 

--- a/test/YieldStreamer.external.test.ts
+++ b/test/YieldStreamer.external.test.ts
@@ -48,7 +48,8 @@ const EVENTS = {
   YieldStreamer_YieldRateAdded: "YieldStreamer_YieldRateAdded",
   YieldStreamer_YieldRateUpdated: "YieldStreamer_YieldRateUpdated",
   YieldStreamer_YieldTransferred: "YieldStreamer_YieldTransferred",
-  YieldStreamerV1Mock_BlocklistCalled: "YieldStreamerV1Mock_BlocklistCalled"
+  YieldStreamerV1Mock_BlocklistCalled: "YieldStreamerV1Mock_BlocklistCalled",
+  YieldStreamer_IsArchivedChanged: "YieldStreamer_IsArchivedChanged"
 };
 
 const ADDRESS_ZERO = ethers.ZeroAddress;
@@ -2183,6 +2184,49 @@ describe("Contract 'YieldStreamer' regarding external functions", async () => {
         .to.be.revertedWithCustomError(yieldStreamer, ERRORS.YieldStreamer_YieldRateArrayIsEmpty);
     });
 
+    it("Returns zeroed values when the contract is archived", async () => {
+      const { yieldStreamer } = await setUpFixture(deployAndConfigureContracts);
+
+      const currentTimestamp = await getLatestBlockAdjustedTimestamp();
+      const nonZeroState: YieldState = {
+        ...defaultYieldState,
+        flags: STATE_FLAG_INITIALIZED,
+        streamYield: 100n,
+        accruedYield: 200n,
+        lastUpdateTimestamp: currentTimestamp - 3600n,
+        lastUpdateBalance: 1000n
+      };
+
+      await proveTx(yieldStreamer.setYieldState(users[0].address, nonZeroState));
+      const previewBeforeRaw = await yieldStreamer.getAccruePreview(users[0].address);
+      const previewBefore = normalizeAccruePreview(previewBeforeRaw);
+
+      expect(previewBefore).to.include({
+        fromTimestamp: nonZeroState.lastUpdateTimestamp,
+        balance: nonZeroState.lastUpdateBalance,
+        streamYieldBefore: nonZeroState.streamYield,
+        accruedYieldBefore: nonZeroState.accruedYield
+      });
+      expect(previewBefore.rates.length).to.be.greaterThan(0);
+      expect(previewBefore.results.length).to.be.greaterThan(0);
+
+      await proveTx(yieldStreamer.setIsArchived(true));
+      const previewAfterRaw = await yieldStreamer.getAccruePreview(users[0].address);
+      const previewAfter = normalizeAccruePreview(previewAfterRaw);
+
+      expect(previewAfter).to.deep.equal({
+        fromTimestamp: 0n,
+        toTimestamp: 0n,
+        balance: 0n,
+        streamYieldBefore: 0n,
+        accruedYieldBefore: 0n,
+        streamYieldAfter: 0n,
+        accruedYieldAfter: 0n,
+        rates: [],
+        results: []
+      });
+    });
+
     // Other test cases are covered in tests for the internal "_getAccruePreview()" function
   });
 
@@ -2250,6 +2294,44 @@ describe("Contract 'YieldStreamer' regarding external functions", async () => {
         .to.be.revertedWithCustomError(yieldStreamer, ERRORS.YieldStreamer_YieldRateArrayIsEmpty);
     });
 
+    it("Returns zeroed values when the contract is archived", async () => {
+      const { yieldStreamer } = await setUpFixture(deployAndConfigureContracts);
+
+      const currentTimestamp = await getLatestBlockAdjustedTimestamp();
+      const nonZeroState: YieldState = {
+        ...defaultYieldState,
+        flags: STATE_FLAG_INITIALIZED,
+        streamYield: 100n,
+        accruedYield: 200n,
+        lastUpdateTimestamp: currentTimestamp - 3600n,
+        lastUpdateBalance: 1000n
+      };
+
+      await proveTx(yieldStreamer.setYieldState(users[0].address, nonZeroState));
+      const previewBeforeRaw = await yieldStreamer.getClaimPreview(users[0].address);
+      const previewBefore = normalizeClaimPreview(previewBeforeRaw);
+
+      expect(previewBefore).to.include({balance: nonZeroState.lastUpdateBalance});
+      expect(previewBefore.rates.length).to.be.greaterThan(0);
+      expect(previewBefore.caps.length).to.be.greaterThan(0);
+      expect(previewBefore.yieldExact).to.be.greaterThanOrEqual(nonZeroState.accruedYield + nonZeroState.streamYield);
+
+      await proveTx(yieldStreamer.setIsArchived(true));
+      const previewAfterRaw = await yieldStreamer.getClaimPreview(users[0].address);
+      const previewAfter = normalizeClaimPreview(previewAfterRaw);
+
+      expect(previewAfter).to.deep.equal({
+        yieldExact: 0n,
+        yieldRounded: 0n,
+        feeExact: 0n,
+        feeRounded: 0n,
+        timestamp: 0n,
+        balance: 0n,
+        rates: [],
+        caps: []
+      });
+    });
+
     // Other test cases are covered in tests for the internal "_getClaimPreview()" function
   });
 
@@ -2266,6 +2348,44 @@ describe("Contract 'YieldStreamer' regarding external functions", async () => {
     it("Executes as expected", async () => {
       const { yieldStreamer } = await setUpFixture(deployAndConfigureContracts);
       await expect(yieldStreamer.proveYieldStreamer()).to.not.be.reverted;
+    });
+  });
+
+  describe("Function 'setIsArchived()'", async () => {
+    it("Sets the isArchived flag correctly when called by owner", async () => {
+      const { yieldStreamer } = await setUpFixture(deployAndConfigureContracts);
+
+      expect(await yieldStreamer.isArchived()).to.equal(false);
+
+      await expect(yieldStreamer.setIsArchived(true))
+        .to.emit(yieldStreamer, EVENTS.YieldStreamer_IsArchivedChanged)
+        .withArgs(true);
+
+      expect(await yieldStreamer.isArchived()).to.equal(true);
+
+      await expect(yieldStreamer.setIsArchived(false))
+        .to.emit(yieldStreamer, EVENTS.YieldStreamer_IsArchivedChanged)
+        .withArgs(false);
+
+      expect(await yieldStreamer.isArchived()).to.equal(false);
+    });
+
+    it("Reverts when trying to archive an already archived contract", async () => {
+      const { yieldStreamer } = await setUpFixture(deployAndConfigureContracts);
+
+      await proveTx(yieldStreamer.setIsArchived(true));
+      expect(await yieldStreamer.isArchived()).to.equal(true);
+
+      await expect(yieldStreamer.setIsArchived(true))
+        .to.be.revertedWithCustomError(yieldStreamer, ERRORS.YieldStreamer_ContractAlreadyArchived);
+    });
+
+    it("Reverts when called by non-owner", async () => {
+      const { yieldStreamer } = await setUpFixture(deployAndConfigureContracts);
+
+      await expect(connect(yieldStreamer, stranger).setIsArchived(true))
+        .to.be.revertedWithCustomError(yieldStreamer, ERRORS.AccessControlUnauthorizedAccount)
+        .withArgs(stranger.address, OWNER_ROLE);
     });
   });
 });


### PR DESCRIPTION
## Main changes

Added the ability to archive the contract and reset all remaining yield when a contract is in an archived state. The remaining yield is reset by returning zero values ​​from the preview functions, but the underlying calculation still continues.

New function and event signatures:

```Solidity
    /**
     * @dev Returns true if the streamer is archived (all yield is zeroed out).
     */
    function isArchived() external view returns (bool);

    /**
     * @dev Sets the archived state of the yield streamer contract.
     * When archived, yield calculation functions return zeroed values.
     *
     * @param isArchived If true, the yield streamer is considered archived.
     */
    function setIsArchived(bool isArchived) external;

    /**
     * @dev Emitted when the archived state of the yield streamer contract is changed.
     *
     * @param isArchived The new archived state of the yield streamer contract.
     */
    event YieldStreamer_IsArchivedChanged(bool isArchived);
```

### Contract version
The contract version was updated from `v2.2.0` to `2.3.0`.

### Test coverage
The changes are covered by the tests.